### PR TITLE
이미지 인식 시 5초간 정지까지 구현

### DIFF
--- a/yolo_drive/launch/line_drive_sr.launch
+++ b/yolo_drive/launch/line_drive_sr.launch
@@ -1,18 +1,4 @@
 <launch>
-
-  <include file="$(find xycar_motor)/launch/xycar_motor.launch" />
-
-  <node name="usb_cam" output="screen" pkg="usb_cam" type="usb_cam_node">
-    <param name="video_device" value="/dev/videoCAM" />
-    <param name="autoexposure" value="false" />
-    <param name="exposure" value="50" />
-    <param name="image_width" value="640" />
-    <param name="image_height" value="480" />
-    <param name="pixel_format" value="yuyv" />
-    <param name="camera_frame_id" value="usb_cam" />
-    <param name="io_method" value="mmap" />
-  </node>
-  
   <!-- darknet_ros -->
     <arg name="yolo_weights_path" default="$(find darknet_ros)/yolo_network_config/weights"/>
     <arg name="yolo_config_path" default="$(find darknet_ros)/yolo_network_config/cfg"/>
@@ -22,11 +8,13 @@
     <rosparam command="load" ns="darknet_ros" file="$(arg network_param_file)"/>
     <arg name="launch_prefix" default=""/>
 
-  <node pkg="darknet_ros" type="darknet_ros" name="darknet_ros" output="screen" launch-prefix="$(arg launch_prefix)">
+  <node pkg="darknet_ros" type="darknet_ros" name="darknet_ros" launch-prefix="$(arg launch_prefix)">
       <param name="weights_path" value="$(arg yolo_weights_path)" />
       <param name="config_path" value="$(arg yolo_config_path)" />
       <remap from="/camera/rgb/image_raw" to="/usb_cam/image_raw"/>
   </node>
+  <node pkg="rosbag" type="play" name="rosbag_play" required="true"
+         args="-r 0.25 --start 80 --duration 30 /home/yjcho/xycar_ws/src/yolo_drive/image.bag"/>
 
   <node name="auto_drive" output="screen" pkg="yolo_drive" type="line_drive_sr.py" />
 

--- a/yolo_drive/src/yolo_steering.py
+++ b/yolo_drive/src/yolo_steering.py
@@ -6,6 +6,7 @@ import time, rospy
 
 
 class YOLO:
+    #rospy.init_node('yolo_drive')
     """
     def __init__(self, image, bridge, Width, Height):
         self.image = np.empty(shape=[0])
@@ -35,12 +36,12 @@ class YOLO:
     """
         
         
-    def image_detect(self, box_data):
-        print('image_detect')
-        person = True
-        cat = True
-        dog = True
-        cow = True
+    def image_detect(self, box_data, person, cat, dog, cow):
+        #print('image_detect')
+        person = person
+        cat = cat
+        dog = dog
+        cow = cow
         #while box_data is None:
             #rate.sleep()
         object1 = "person"
@@ -48,27 +49,31 @@ class YOLO:
         object3 = "dog"
         object4 = "cow"
         boxes = box_data
+
         if boxes is not None:
             for i in range(len(boxes.bounding_boxes)):
-                if (boxes.bounding_boxes[i].Class == object1 and person == True) and boxes.bounding_boxes[i].probability >= 0.35:
-                    person = False
-                    print('Class : ', boxes.bounding_boxes[i].Class)
-                    return True
-                elif (boxes.bounding_boxes[i].Class == object2 and cat == True) and boxes.bounding_boxes[i].probability >= 0.35:
-                    cat = False
-                    print('Class : ', boxes.bounding_boxes[i].Class)
-                    return True
-                elif (boxes.bounding_boxes[i].Class == object3 and dog == True) and boxes.bounding_boxes[i].probability >= 0.35:
-                    dog = False
-                    print('Class : ', boxes.bounding_boxes[i].Class)
-                    return True
+                width = box_data.bounding_boxes[i].xmax - box_data.bounding_boxes[i].xmin
+                height = box_data.bounding_boxes[i].ymax - box_data.bounding_boxes[i].ymin
+                #print(width, height)
+                if (boxes.bounding_boxes[i].Class == object1 and person == True) and boxes.bounding_boxes[i].probability >= 0.35 and width*height > 41000:
+                    #person = True
+                    #print('Class : ', boxes.bounding_boxes[i].Class)
+                    return 'person'
+                elif (boxes.bounding_boxes[i].Class == object2 and cat == True) and boxes.bounding_boxes[i].probability >= 0.35 and width*height > 22500:
+                    #cat = True
+                    #print('Class : ', boxes.bounding_boxes[i].Class)
+                    return 'cat'
+                elif (boxes.bounding_boxes[i].Class == object3 and dog == True) and boxes.bounding_boxes[i].probability >= 0.35 and width*height > 8400:
+                    #dog = True
+                    #print('Class : ', boxes.bounding_boxes[i].Class)
+                    return 'dog'
                 elif (boxes.bounding_boxes[i].Class == object4 and cow == True) and boxes.bounding_boxes[i].probability >= 0.35:
-                    cow = False
-                    print('Class : ', boxes.bounding_boxes[i].Class)
-                    return True
+                    #cow = True
+                    #print('Class : ', boxes.bounding_boxes[i].Class)
+                    return 'cow'
                 else:
                     return False
         
-    #rate = rospy.Rate(10)
+        #rate = rospy.Rate(1)
         
 


### PR DESCRIPTION
이미지 인식 후 5초간 정지한 후 다시 출발하게 구현하였습니다. 기존의 이미지 인식 후 다시 인식하는 문제 해결하였습니다. 추가로, Class화 하는 작업과, 모든 이미지를 인식하지 못하였을 때 다시 한바퀴 도는 코드 구현 필요.